### PR TITLE
Add CommonJS compatibility to package.json exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js"
-    }
+      "import": "./dist/src/index.js",
+      "require": "./dist/src/index.js"
+    },
+    "./bin": "./bin/index.js"
   },
   "bin": {
     "address-parser": "./bin/index.js"


### PR DESCRIPTION
This pull request fixes the ERR_PACKAGE_PATH_NOT_EXPORTED error that occurs when using the @universe/address-parser package in a CommonJS environment. The issue was caused by the exports field in the package.json missing a require path for CommonJS compatibility.

The error prevents the package from being used in projects that rely on CommonJS (require). Adding the require path ensures compatibility with both CommonJS and ES modules.

This PR addresses Issue #4 .